### PR TITLE
Add STSM blog post submission template and update routing instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/05_grant_call.yml
+++ b/.github/ISSUE_TEMPLATE/05_grant_call.yml
@@ -1,5 +1,5 @@
 ﻿name: "Grant or STSM call content"
-description: "Create or update grant call pages and related announcements"
+description: "Create or update grant or STSM call pages"
 title: "[Grant call]: "
 labels:
   - "💶 area:grants"
@@ -9,14 +9,18 @@ assignees:
   - OndrejMottl
   - xbenitogranell
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for **call pages only**.
+        For post-STSM narrative submissions, use **08_stsm_blogpost.yml**.
   - type: dropdown
     id: request-kind
     attributes:
-      label: Request type
+      label: Call request type
       options:
         - New call page
         - Update existing call page
-        - Blog or report from funded activity
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/08_stsm_blogpost.yml
+++ b/.github/ISSUE_TEMPLATE/08_stsm_blogpost.yml
@@ -1,0 +1,183 @@
+name: "STSM blog post"
+description: "Submit a post-STSM blog or report from a funded activity"
+title: "[STSM Blog]: "
+labels:
+  - "💶 area:grants"
+  - "✍️ type:new-content"
+  - "❓ status:needs-info"
+assignees:
+  - OndrejMottl
+  - xbenitogranell
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for post-STSM blog submissions.
+
+        Include enough detail so the page can be drafted without follow-up.
+        The final page should end with: *This STSM was funded by the COST Action CA23116 — PalaeOpen.*
+
+        If your report is in MS Word, paste it as-is in **Full blog content**. Markdown formatting is optional.
+  - type: input
+    id: source-file
+    attributes:
+      label: Source file (if known)
+      description: If unknown, write unknown.
+      value: unknown
+    validations:
+      required: false
+  - type: dropdown
+    id: submission-format
+    attributes:
+      label: Submission format
+      options:
+        - Written blog post
+        - Short video with written summary
+    validations:
+      required: true
+  - type: input
+    id: stsm-cycle
+    attributes:
+      label: STSM call cycle (if known)
+      placeholder: STSM 2026 - 3rd call
+    validations:
+      required: false
+  - type: input
+    id: author-name
+    attributes:
+      label: Author name
+      placeholder: First Last
+    validations:
+      required: true
+  - type: input
+    id: author-institution
+    attributes:
+      label: Home institution
+      placeholder: University, City, Country
+    validations:
+      required: true
+  - type: input
+    id: host-institution
+    attributes:
+      label: Host institution
+      placeholder: Host University, City, Country
+    validations:
+      required: true
+  - type: input
+    id: host-supervisor
+    attributes:
+      label: Host supervisor or contact
+      placeholder: First Last, role, email
+    validations:
+      required: false
+  - type: input
+    id: stsm-dates
+    attributes:
+      label: STSM dates
+      placeholder: 2026-03-01 to 2026-03-21
+    validations:
+      required: true
+  - type: input
+    id: target-path
+    attributes:
+      label: Proposed file path (optional)
+      description: Use snake_case naming.
+      placeholder: grants/stms/blogs/author_city_2026.qmd
+    validations:
+      required: false
+  - type: input
+    id: blog-title
+    attributes:
+      label: Blog post title
+      placeholder: My STSM experience at Host Institution
+    validations:
+      required: true
+  - type: textarea
+    id: blog-summary
+    attributes:
+      label: One-paragraph summary (optional)
+      description: If not provided, it will be drafted from the full text.
+      render: markdown
+      value: |
+        Provide a concise summary of your STSM and main outcomes.
+    validations:
+      required: false
+  - type: textarea
+    id: blog-content
+    attributes:
+      label: Full blog content (Word text is fine)
+      description: Paste the complete report text. Keep figure callouts such as "Figure 1" in the text.
+      render: markdown
+      value: |
+        ## Who?
+
+        State your role (for example, Early Career Researcher), your home institution, and your background.
+
+        ## Where?
+
+        State the host institution, city, and country.
+
+        ## When?
+
+        State your STSM dates.
+
+        ## Overview
+
+        Describe the goal of your STSM and your host institution.
+
+        ## What I worked on
+
+        Describe methods, data, tools, and collaboration.
+
+        ## Outcomes and next steps
+
+        Summarize key outcomes and follow-up plans.
+
+        ## Acknowledgements
+
+        Include collaborators and the required funding sentence.
+    validations:
+      required: true
+  - type: textarea
+    id: figure-captions-credits
+    attributes:
+      label: Figure captions and photo credits
+      description: Include each figure caption and photo credit exactly as it should appear.
+      render: markdown
+      value: |
+        - Figure 1. Caption text. Photo credit: Name.
+        - Figure 2. Caption text. Photo credit: Name.
+    validations:
+      required: false
+  - type: textarea
+    id: visuals
+    attributes:
+      label: Images or media
+      description: List file names or URLs and short captions. Include one preferred featured image.
+      value: |
+        - Featured image: filename or URL (caption)
+        - Image 2: filename or URL (caption)
+        - Optional video URL:
+        - Optional folder link (Google Drive/OneDrive):
+    validations:
+      required: false
+  - type: textarea
+    id: links
+    attributes:
+      label: Related links
+      value: |
+        - https://...
+        - https://...
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I confirm I am the author or have permission to submit this content.
+          required: true
+        - label: I confirm all links and dates are correct.
+          required: true
+        - label: I confirm any images/media can be published by PalaeOpen.
+          required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,6 +71,11 @@ All content requests come via one of these structured GitHub Issue templates:
 | `05_grant_call.yml` | Grant / STSM call pages |
 | `06_archive_remove.yml` | Archive or remove content |
 | `07_website_bug.yml` | Bug report |
+| `08_stsm_blogpost.yml` | STSM blog post submission from funded activity |
+
+Routing note:
+- Use `05_grant_call.yml` for grant/STSM call page creation and updates.
+- Use `08_stsm_blogpost.yml` for post-STSM blog submissions from funded activities.
 
 ## Agent Workflow (Issue → PR)
 

--- a/.github/instructions/grants.instructions.md
+++ b/.github/instructions/grants.instructions.md
@@ -130,3 +130,10 @@ When instructed to update (e.g., extend deadline, add results):
 - Keep the original content intact; add/replace only the changed fields.
 - Update `date-modified: last-modified` is handled automatically by Quarto.
 - If deadline changes, update both the callout dates and any inline text that references the date.
+
+## Issue Template Routing
+
+When processing GitHub issues:
+
+- Use `05_grant_call.yml` for STSM/grant call page creation and updates.
+- Use `08_stsm_blogpost.yml` for post-STSM blog submissions from funded activities.


### PR DESCRIPTION
Introduce a new template for submitting post-STSM blog posts and update routing instructions for grant and STSM call pages. This enhances clarity for users submitting content.